### PR TITLE
Don't run a server side fetch for different anchors at the same URL

### DIFF
--- a/packages/fastify-renderer/src/client/react/Root.tsx
+++ b/packages/fastify-renderer/src/client/react/Root.tsx
@@ -42,13 +42,14 @@ export function Root<BootProps>(props: {
       <Route path={route} key={route}>
         {(params) => {
           const [location] = useLocation()
+          const backendPath = location.split('#')[0] // remove current anchor for fetching data from the server side
 
-          const payload = usePromise<{ props: Record<string, any> }>(props.basePath + location, async () => {
+          const payload = usePromise<{ props: Record<string, any> }>(props.basePath + backendPath, async () => {
             if (!firstRenderComplete) {
               return { props: props.bootProps }
             } else {
               return (
-                await fetch(props.basePath + location, {
+                await fetch(props.basePath + backendPath, {
                   method: 'GET',
                   headers: {
                     Accept: 'application/json',

--- a/packages/test-apps/simple-react/test/navigation-details.spec.ts
+++ b/packages/test-apps/simple-react/test/navigation-details.spec.ts
@@ -22,7 +22,13 @@ describe('navigation details', () => {
     expect(testCalls[1].navigationDestination).toBe('/')
   })
 
-  test('navigation to new anchors on the same page triggers a fastify-renderer navigation', async () => {
+  test('navigation to new anchors on the same page triggers a fastify-renderer navigation but no data fetch', async () => {
+    page.on('request', (request) => {
+      throw new Error(
+        `Expecting no requests to be made during hash navigation, request made: ${request.method()} ${request.url()}`
+      )
+    })
+
     await page.click('#section-link')
 
     const testCalls: any[] = await page.evaluate('window.test')


### PR DESCRIPTION
We noticed this issue where `fastify-renderer` was refetching a page's props from the server when navigating to the same URL but at a different anchor, like `/foo` => `/foo#bar`.  This is a purely client side navigation where the client already has all the information necessary to render the page. We assume the contents don't change. Someday, we're gonna need a way for the application to manage the cache, we don't have that yet, but that'd be the way to tell fastify-renderer to force reload the data from the server.