### PR TITLE
Add support for multiple contexts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ const server = fastify()
 server.register(renderer)
 ```
 
+## Docs
+
+- [Navigating between routes from different Fastify contexts](./docs/fastify-contexts)
+
 ## License
 
 [MIT](./LICENSE)

--- a/docs/fastify-contexts.md
+++ b/docs/fastify-contexts.md
@@ -1,0 +1,26 @@
+# Fastify encapsulation contexts
+
+## Overview
+One of the main features of Fastify is its support for different [encapsulation contexts](https://www.fastify.io/docs/latest/Encapsulation/), the context at which a route is registered determines which hooks, plugins, and decorators are available to it. 
+
+For `fastify-renderer`, contexts are used to allow more customization and configuration for `vite` rendering options.
+
+More specifically, it is possible to provide a custom `layout` to be used for rendering routes in a specific context.
+
+*Note: Providing a different `layout` requires that you specifiy a new `base` as well.*
+
+## Navigating between contexts
+Since the router instance is only aware of routes in the current context, navigating to a route in a different context requires bypassing the router. 
+
+This can be done in a couple of ways:
+1. Using a `<Link>` tag but specifying the href property as an absolute path by prefixing it with a `~`
+2. Using an `<a>` tag instead of a `<Link>` tag from `wouter`
+
+## Example
+
+```html
+<!-- The router requests the page from the server -->
+<Link href="~/">Home</Link>
+<!-- The browser requests the page from the server without going through the router -->
+<a href="/">Home</a>
+```

--- a/packages/fastify-renderer/src/client/react/locationHook.ts
+++ b/packages/fastify-renderer/src/client/react/locationHook.ts
@@ -55,13 +55,19 @@ export const useTransitionLocation = ({ base = '' } = {}) => {
   // the function reference should stay the same between re-renders, so that
   // it can be passed down as an element prop without any performance concerns.
   const navigate = useCallback(
-    (to, { replace = false } = {}) =>
+    (to, { replace = false } = {}) => {
+      if (to[0] === '~') {
+        window.location.href = to.slice(1)
+        return
+      }
+
       history[replace ? eventReplaceState : eventPushState](
         null,
         '',
         // handle nested routers and absolute paths
-        to[0] === '~' ? to.slice(1) : base + to
-      ),
+        base + to
+      )
+    },
     [base]
   )
 

--- a/packages/fastify-renderer/src/node/index.ts
+++ b/packages/fastify-renderer/src/node/index.ts
@@ -9,7 +9,7 @@ import path from 'path'
 import { build as viteBuild, createServer, InlineConfig, resolveConfig, ResolvedConfig, ViteDevServer } from 'vite'
 import { DefaultDocumentTemplate } from './DocumentTemplate'
 import { FastifyRendererOptions, FastifyRendererPlugin } from './Plugin'
-import { Render, RenderableRoute, RenderOptions } from './renderers/Renderer'
+import { PartialRenderOptions, Render, RenderableRoute, RenderOptions } from './renderers/Renderer'
 import { kRendererPlugin, kRendererViteOptions, kRenderOptions } from './symbols'
 import { wrap } from './tracing'
 import './types' // necessary to make sure that the fastify types are augmented
@@ -21,7 +21,7 @@ declare module 'fastify' {
     [kRendererPlugin]: FastifyRendererPlugin
     [kRendererViteOptions]: InlineConfig
     [kRenderOptions]: RenderOptions
-    setRenderConfig(options: FastifyRendererOptions): void
+    setRenderConfig(options: PartialRenderOptions): void
   }
 }
 
@@ -49,7 +49,7 @@ const FastifyRenderer = fp<FastifyRendererOptions>(
       instance[kRenderOptions] = innerOptions
     })
 
-    fastify.decorate('setRenderConfig', function (this: FastifyInstance, config: Partial<RenderOptions>) {
+    fastify.decorate('setRenderConfig', function (this: FastifyInstance, config: PartialRenderOptions) {
       const newOptions = { ...this[kRenderOptions], ...config }
       if (newOptions.base.endsWith('/')) {
         this.log.warn(`fastify-renderer base paths shouldn't end in a slash, got ${newOptions.base}`)

--- a/packages/fastify-renderer/src/node/index.ts
+++ b/packages/fastify-renderer/src/node/index.ts
@@ -50,6 +50,10 @@ const FastifyRenderer = fp<FastifyRendererOptions>(
     })
 
     fastify.decorate('setRenderConfig', function (this: FastifyInstance, config: PartialRenderOptions) {
+      if ('layout' in config && !('base' in config)) {
+        throw new Error('The base property is required when setting a new layout')
+      }
+
       const newOptions = { ...this[kRenderOptions], ...config }
       if (newOptions.base.endsWith('/')) {
         this.log.warn(`fastify-renderer base paths shouldn't end in a slash, got ${newOptions.base}`)

--- a/packages/fastify-renderer/src/node/renderers/Renderer.ts
+++ b/packages/fastify-renderer/src/node/renderers/Renderer.ts
@@ -9,6 +9,13 @@ export interface RenderOptions {
   base: string
 }
 
+export type PartialRenderOptions =
+  | { layout: string; document: Template; base: string }
+  | { layout: string; base: string }
+  | { document: Template; base: string }
+  | { base: string }
+  | { document: Template }
+
 /** One renderable route */
 export interface RenderableRoute extends RenderOptions {
   url: string

--- a/packages/test-apps/simple-react/About.tsx
+++ b/packages/test-apps/simple-react/About.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { Link } from 'wouter'
 
 const About = (props: { hostname: string; requestIP: string }) => {
   return (
@@ -8,6 +9,8 @@ const About = (props: { hostname: string; requestIP: string }) => {
       <p>
         This page was rendered on {props.hostname} for {props.requestIP}
       </p>
+      <br />
+      <Link href="~/">Home</Link>
     </>
   )
 }

--- a/packages/test-apps/simple-react/Home.tsx
+++ b/packages/test-apps/simple-react/Home.tsx
@@ -7,13 +7,11 @@ const Home = (props: { time: number }) => {
       <h1>Hello</h1>
       <p>Hi.</p>
       <p suppressHydrationWarning={true}>This page was rendered at {props.time}</p>
-      <Link href="about">
-        <a>About</a>
-      </Link>
+      <Link href="about"> About</Link>
       <br />
-      <Link href="red/about">
-        <a>Red About</a>
-      </Link>
+      <Link href="~/red/about"> Red About </Link>
+      <br />
+      <Link href="navigation-test"> Navigation Test </Link>
     </>
   )
 }

--- a/packages/test-apps/simple-react/Home.tsx
+++ b/packages/test-apps/simple-react/Home.tsx
@@ -7,9 +7,13 @@ const Home = (props: { time: number }) => {
       <h1>Hello</h1>
       <p>Hi.</p>
       <p suppressHydrationWarning={true}>This page was rendered at {props.time}</p>
-      <Link href="about"> About</Link>
+      <Link id="about-link" href="about">
+        About
+      </Link>
       <br />
-      <Link href="~/red/about"> Red About </Link>
+      <Link id="red-about-link" href="~/red/about">
+        Red About
+      </Link>
       <br />
       <Link href="navigation-test"> Navigation Test </Link>
     </>

--- a/packages/test-apps/simple-react/server.ts
+++ b/packages/test-apps/simple-react/server.ts
@@ -44,7 +44,7 @@ export const server = async () => {
   })
 
   await server.register(async (instance) => {
-    instance.setRenderConfig({ layout: require.resolve('./RedLayout') })
+    instance.setRenderConfig({ base: '/red', layout: require.resolve('./RedLayout') })
 
     instance.get('/red/about', { render: require.resolve('./About') }, async (request) => {
       return { hostname: os.hostname(), requestIP: request.ip }

--- a/packages/test-apps/simple-react/test/switching-contexts.spec.ts
+++ b/packages/test-apps/simple-react/test/switching-contexts.spec.ts
@@ -1,0 +1,33 @@
+import { Page } from 'playwright-chromium'
+import { newTestPage, reactReady, rootURL } from '../../helpers'
+
+describe('navigation details', () => {
+  let page: Page
+
+  beforeEach(async () => {
+    page = await newTestPage()
+    await page.goto(`${rootURL}`)
+    await reactReady(page)
+  })
+
+  test('navigating between pages of the same context doesnt trigger a server side render request', async () => {
+    page.on('request', (request) => {
+      if (request.headers().accept !== 'application/json') {
+        throw new Error(`Expecting request to only fetch props, request made: ${request.method()} ${request.url()}`)
+      }
+    })
+
+    await page.click('#about-link')
+  })
+
+  test('navigating between pages of different contexts triggers a server side render request', async () => {
+    page.on('request', (request) => {
+      console.log(request.headers())
+      if (request.headers().accept === 'application/json') {
+        throw new Error(`Expecting request to trigger SSR, request made: ${request.method()} ${request.url()}`)
+      }
+    })
+
+    await page.click('#red-about-link')
+  })
+})

--- a/packages/test-apps/simple-react/test/switching-contexts.spec.ts
+++ b/packages/test-apps/simple-react/test/switching-contexts.spec.ts
@@ -22,7 +22,6 @@ describe('navigation details', () => {
 
   test('navigating between pages of different contexts triggers a server side render request', async () => {
     page.on('request', (request) => {
-      console.log(request.headers())
       if (request.headers().accept === 'application/json') {
         throw new Error(`Expecting request to trigger SSR, request made: ${request.method()} ${request.url()}`)
       }


### PR DESCRIPTION
To do:
- [x] Add tests
- [x] Add documentation section that explains how to navigate between different contexts (either using Link components with absolute paths, or directly using an `<a>` tag)