### PR TITLE
Loosen matcher restrictions to also allow query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint:fix": "prettier --loglevel warn --write \"packages/**/*.{ts,tsx}\" && eslint \"packages/**/*.{ts,tsx}\" --quiet --fix",
     "release": "yarn workspace fastify-renderer publish",
     "prerelease": "yarn workspace fastify-renderer run gitpkg publish",
-    "test": "jest --forceExit",
+    "test": "jest --forceExit -w=1",
     "test:debug": "cross-env FR_DEBUG_SERVE=1 node --inspect-brk ./node_modules/.bin/jest --forceExit"
   },
   "repository": {

--- a/packages/fastify-renderer/src/client/react/matcher.ts
+++ b/packages/fastify-renderer/src/client/react/matcher.ts
@@ -20,7 +20,7 @@ const getRegexp = (pattern: string) => cache[pattern] || (cache[pattern] = conve
 
 export const matcher: MatcherFn = (pattern, path) => {
   const { regexp, keys } = getRegexp(pattern || '')
-  const out = regexp.exec(path.split('#')[0])
+  const out = regexp.exec(path.split('#')[0].split('?')[0])
 
   if (!out) return [false, null]
 

--- a/packages/test-apps/simple-react/test/navigation-details.spec.ts
+++ b/packages/test-apps/simple-react/test/navigation-details.spec.ts
@@ -38,4 +38,18 @@ describe('navigation details', () => {
     expect(testCalls[1].isNavigating).toBe(true)
     expect(testCalls[1].navigationDestination).toBe('/navigation-test#section')
   })
+
+  test('ensure navigation to pages with query parameters does not consider the query parameters as part of the route match', async () => {
+    await page.goto(`${rootURL}/`)
+    await reactReady(page)
+
+    await page.goto(`${rootURL}/navigation-test?foo=bar#section`)
+    await reactReady(page)
+
+    const testCalls: any[] = await page.evaluate('window.test')
+    expect(testCalls).toBeDefined()
+    expect(testCalls).toHaveLength(3)
+    expect(testCalls[2].isNavigating).toBe(false)
+    expect(testCalls[2].navigationDestination).toBe('/navigation-test?foo=bar#section')
+  })
 })


### PR DESCRIPTION
Our matcher ignores anchor tags when matching routes, it should also ignore query parameters