### PR TITLE
Call renderToString before running head hooks so that ssr styles are generated

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ You can optionally provide configuration options to the plugin:
   - `heads` - Function that will return html tags to be appended to the document head tag
   - `tails` - Function that will return html tags to be appended to the document body tag
   - `transform` - Function that will be run to transform the root react element
+  - `postRenderHeads` - Function (called after render) that will return html tags to be appended to the document head tag. Useful when injecting styles that rely on rendering first.
 
 
 ## Setting up a route

--- a/packages/fastify-renderer/src/node/DocumentTemplate.tsx
+++ b/packages/fastify-renderer/src/node/DocumentTemplate.tsx
@@ -6,6 +6,7 @@ export interface TemplateData<Props> {
   tail: NodeJS.ReadableStream
   content: string | NodeJS.ReadableStream
   props: Props
+  postRenderHead: NodeJS.ReadableStream
 }
 
 /** A template renders out a full HTML document given the content for the document and the scripts for the document, and can optionally grab values out of the props to use for other bits like the page title, metatags, or non-client-side-hydrated body content. */
@@ -19,6 +20,7 @@ export const DefaultDocumentTemplate: Template = (data: TemplateData<any>) => te
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${data.props.title || 'Fastify Renderer App'}</title>
     ${data.head}
+    ${data.postRenderHead}
   </head>
   <body>
     <div id="fstrapp">${data.content}</div>

--- a/packages/fastify-renderer/src/node/DocumentTemplate.tsx
+++ b/packages/fastify-renderer/src/node/DocumentTemplate.tsx
@@ -6,7 +6,6 @@ export interface TemplateData<Props> {
   tail: NodeJS.ReadableStream
   content: string | NodeJS.ReadableStream
   props: Props
-  postRenderHead: NodeJS.ReadableStream
 }
 
 /** A template renders out a full HTML document given the content for the document and the scripts for the document, and can optionally grab values out of the props to use for other bits like the page title, metatags, or non-client-side-hydrated body content. */
@@ -20,7 +19,6 @@ export const DefaultDocumentTemplate: Template = (data: TemplateData<any>) => te
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>${data.props.title || 'Fastify Renderer App'}</title>
     ${data.head}
-    ${data.postRenderHead}
   </head>
   <body>
     <div id="fstrapp">${data.content}</div>

--- a/packages/fastify-renderer/src/node/Plugin.ts
+++ b/packages/fastify-renderer/src/node/Plugin.ts
@@ -9,7 +9,6 @@ import { ReactRenderer, ReactRendererOptions } from './renderers/react/ReactRend
 import { RenderableRoute, Renderer } from './renderers/Renderer'
 import './types' // necessary to make sure that the fastify types are augmented
 import { FastifyRendererHook, ServerEntrypointManifest, ViteClientManifest } from './types'
-import { unthunk } from './utils'
 
 export interface FastifyRendererOptions {
   renderer?: ReactRendererOptions
@@ -31,7 +30,7 @@ export class FastifyRendererPlugin {
   clientOutDir: string
   serverOutDir: string
   assetsHost: string
-  hooks: FastifyRendererHook[]
+  hooks: (FastifyRendererHook | (() => FastifyRendererHook))[]
   clientManifest?: ViteClientManifest
   serverEntrypointManifest?: ServerEntrypointManifest
   routes: RenderableRoute[] = []
@@ -43,7 +42,7 @@ export class FastifyRendererPlugin {
     this.vite.base ??= '/.vite/'
     this.viteBase = this.vite.base
     this.assetsHost = incomingOptions.assetsHost || ''
-    this.hooks = (incomingOptions.hooks || []).map(unthunk)
+    this.hooks = incomingOptions.hooks || []
 
     const outDir = incomingOptions.outDir || path.join(process.cwd(), 'dist')
     this.clientOutDir = path.join(outDir, 'client', this.viteBase)

--- a/packages/fastify-renderer/src/node/renderers/react/ReactRenderer.tsx
+++ b/packages/fastify-renderer/src/node/renderers/react/ReactRenderer.tsx
@@ -221,8 +221,8 @@ export class ReactRenderer implements Renderer {
     ReactDOMServer: any,
     render: Render<Props>
   ) {
-    this.runHeadHooks(bus)
     const content = ReactDOMServer.renderToString(app)
+    this.runHeadHooks(bus)
     this.runTailHooks(bus)
 
     return render.document({

--- a/packages/fastify-renderer/src/node/renderers/react/ReactRenderer.tsx
+++ b/packages/fastify-renderer/src/node/renderers/react/ReactRenderer.tsx
@@ -7,7 +7,8 @@ import { normalizePath } from 'vite/dist/node'
 import { FastifyRendererPlugin } from '../../Plugin'
 import { RenderBus } from '../../RenderBus'
 import { wrap } from '../../tracing'
-import { mapFilepathToEntrypointName } from '../../utils'
+import { FastifyRendererHook } from '../../types'
+import { mapFilepathToEntrypointName, unthunk } from '../../utils'
 import { Render, RenderableRoute, Renderer } from '../Renderer'
 
 const CLIENT_ENTRYPOINT_PREFIX = '/@fstr!entrypoint:'
@@ -79,6 +80,7 @@ export class ReactRenderer implements Renderer {
   /** Renders a given request and sends the resulting HTML document out with the `reply`. */
   private wrappedRender = wrap('fastify-renderer.render', async <Props,>(render: Render<Props>): Promise<void> => {
     const bus = this.startRenderBus(render)
+    const hooks = this.plugin.hooks.map(unthunk)
 
     try {
       const url = this.entrypointRequirePathForServer(render)
@@ -97,16 +99,16 @@ export class ReactRenderer implements Renderer {
         </RenderBusContext.Provider>
       )
 
-      for (const hook of this.plugin.hooks) {
+      for (const hook of hooks) {
         if (hook.transform) {
           app = hook.transform(app)
         }
       }
 
       if (this.options.mode == 'streaming') {
-        await render.reply.send(this.renderStreamingTemplate(app, bus, ReactDOMServer, render))
+        await render.reply.send(this.renderStreamingTemplate(app, bus, ReactDOMServer, render, hooks))
       } else {
-        await render.reply.send(this.renderSynchronousTemplate(app, bus, ReactDOMServer, render))
+        await render.reply.send(this.renderSynchronousTemplate(app, bus, ReactDOMServer, render, hooks))
       }
     } catch (error: unknown) {
       this.devServer?.ssrFixStacktrace(error as Error)
@@ -203,14 +205,20 @@ export class ReactRenderer implements Renderer {
     return bus
   }
 
-  private renderStreamingTemplate<Props>(app: JSX.Element, bus: RenderBus, ReactDOMServer: any, render: Render<Props>) {
-    this.runHeadHooks(bus)
+  private renderStreamingTemplate<Props>(
+    app: JSX.Element,
+    bus: RenderBus,
+    ReactDOMServer: any,
+    render: Render<Props>,
+    hooks: FastifyRendererHook[]
+  ) {
+    this.runHeadHooks(bus, hooks)
     // There are not postRenderHead hooks for streaming templates
     // so let's end the head stack
     bus.push('head', null)
     const contentStream = ReactDOMServer.renderToNodeStream(app)
     contentStream.on('end', () => {
-      this.runTailHooks(bus)
+      this.runTailHooks(bus, hooks)
     })
 
     return render.document({
@@ -225,12 +233,13 @@ export class ReactRenderer implements Renderer {
     app: JSX.Element,
     bus: RenderBus,
     ReactDOMServer: any,
-    render: Render<Props>
+    render: Render<Props>,
+    hooks: FastifyRendererHook[]
   ) {
-    this.runHeadHooks(bus)
+    this.runHeadHooks(bus, hooks)
     const content = ReactDOMServer.renderToString(app)
-    this.runPostRenderHeadHooks(bus)
-    this.runTailHooks(bus)
+    this.runPostRenderHeadHooks(bus, hooks)
+    this.runTailHooks(bus, hooks)
 
     return render.document({
       content,
@@ -240,9 +249,9 @@ export class ReactRenderer implements Renderer {
     })
   }
 
-  private runPostRenderHeadHooks(bus: RenderBus) {
+  private runPostRenderHeadHooks(bus: RenderBus, hooks: FastifyRendererHook[]) {
     // Run any heads hooks that might want to push something after the content
-    for (const hook of this.plugin.hooks) {
+    for (const hook of hooks) {
       if (hook.postRenderHeads) {
         bus.push('head', hook.postRenderHeads())
       }
@@ -250,18 +259,18 @@ export class ReactRenderer implements Renderer {
     bus.push('head', null)
   }
 
-  private runHeadHooks(bus: RenderBus) {
+  private runHeadHooks(bus: RenderBus, hooks: FastifyRendererHook[]) {
     // Run any heads hooks that might want to push something before the content
-    for (const hook of this.plugin.hooks) {
+    for (const hook of hooks) {
       if (hook.heads) {
         bus.push('head', hook.heads())
       }
     }
   }
 
-  private runTailHooks(bus: RenderBus) {
+  private runTailHooks(bus: RenderBus, hooks: FastifyRendererHook[]) {
     // when we're done rendering the content, run any hooks that might want to push more stuff after the content
-    for (const hook of this.plugin.hooks) {
+    for (const hook of hooks) {
       if (hook.tails) {
         bus.push('tail', hook.tails())
       }

--- a/packages/fastify-renderer/src/node/types.ts
+++ b/packages/fastify-renderer/src/node/types.ts
@@ -25,6 +25,7 @@ export interface FastifyRendererHook {
   tails?: () => string
   heads?: () => string
   transform?: (app: ReactElement) => ReactElement
+  postRenderHeads?: () => string
 }
 
 export interface ViteClientManifest {

--- a/packages/fastify-renderer/test/helpers.ts
+++ b/packages/fastify-renderer/test/helpers.ts
@@ -1,9 +1,12 @@
 import fastify, { FastifyServerOptions } from 'fastify'
 import fastifyAccepts from 'fastify-accepts'
 import Middie from 'middie'
+import path from 'path'
+import { Readable } from 'stream'
 import { FastifyRendererOptions, FastifyRendererPlugin } from '../src/node/Plugin'
 import { RenderBus } from '../src/node/RenderBus'
 import { ReactRenderer, ReactRendererOptions } from '../src/node/renderers/react/ReactRenderer'
+import { Render } from '../src/node/renderers/Renderer'
 
 const logLevel = process.env.LOG_LEVEL || 'error'
 
@@ -25,4 +28,23 @@ export const newFastifyRendererPlugin = (options: FastifyRendererOptions = {}) =
 export const newReactRenderer = (options?: ReactRendererOptions): ReactRenderer => {
   const plugin = newFastifyRendererPlugin({ renderer: options })
   return plugin.renderer as ReactRenderer
+}
+
+export const getMockRender = <T>(props: T): Render<T> => {
+  return {
+    props,
+    renderable: path.resolve(__dirname, 'fixtures', 'test-module.tsx'),
+    url: 'test-url',
+    layout: path.resolve(__dirname, 'fixtures', 'test-layout.tsx'),
+    base: '',
+    document: (data) => Readable.from(''),
+    request: {
+      url: 'test-url',
+    } as any,
+    reply: {
+      send: (payload: unknown) => {
+        throw new Error('Send is not implemented')
+      },
+    } as any,
+  }
 }

--- a/packages/fastify-renderer/test/renderers/ReactRenderer.spec.ts
+++ b/packages/fastify-renderer/test/renderers/ReactRenderer.spec.ts
@@ -52,18 +52,6 @@ describe('ReactRenderer', () => {
     test('should call postRenderHooks after dom render', async () => {
       const renderer = newReactRenderer()
       const callOrder: string[] = []
-      renderer.plugin.hooks = [
-        {
-          heads: () => {
-            callOrder.push('heads')
-            return 'heads'
-          },
-          postRenderHeads: () => {
-            callOrder.push('postRenderHeads')
-            return 'postRenderHeads'
-          },
-        },
-      ]
 
       renderer['renderSynchronousTemplate'](
         React.createElement(testLayoutComponent, {}),
@@ -74,7 +62,19 @@ describe('ReactRenderer', () => {
             return 'test'
           },
         },
-        getMockRender({})
+        getMockRender({}),
+        [
+          {
+            heads: () => {
+              callOrder.push('heads')
+              return 'heads'
+            },
+            postRenderHeads: () => {
+              callOrder.push('postRenderHeads')
+              return 'postRenderHeads'
+            },
+          },
+        ]
       )
 
       expect(callOrder).toEqual(['heads', 'render', 'postRenderHeads'])

--- a/packages/fastify-renderer/test/renderers/ReactRenderer.spec.ts
+++ b/packages/fastify-renderer/test/renderers/ReactRenderer.spec.ts
@@ -1,7 +1,10 @@
-// import { ReactRenderer } from "../../src/node/renderers/react/ReactRenderer";
+import path from 'path'
+import React from 'react'
 import { DefaultDocumentTemplate } from '../../src/node/DocumentTemplate'
 import { RenderableRoute } from '../../src/node/renderers/Renderer'
-import { newReactRenderer } from '../helpers'
+import { getMockRender, newReactRenderer, newRenderBus } from '../helpers'
+
+const testLayoutComponent = require.resolve(path.join(__dirname, '..', 'fixtures', 'test-layout.tsx'))
 
 describe('ReactRenderer', () => {
   test('should create an instance and initialize the client module path', async () => {
@@ -44,6 +47,37 @@ describe('ReactRenderer', () => {
 
     test.skip('should throw on rendering failure', async () => {
       return
+    })
+
+    test('should call postRenderHooks after dom render', async () => {
+      const renderer = newReactRenderer()
+      const callOrder: string[] = []
+      renderer.plugin.hooks = [
+        {
+          heads: () => {
+            callOrder.push('heads')
+            return 'heads'
+          },
+          postRenderHeads: () => {
+            callOrder.push('postRenderHeads')
+            return 'postRenderHeads'
+          },
+        },
+      ]
+
+      renderer['renderSynchronousTemplate'](
+        React.createElement(testLayoutComponent, {}),
+        newRenderBus(),
+        {
+          renderToString: () => {
+            callOrder.push('render')
+            return 'test'
+          },
+        },
+        getMockRender({})
+      )
+
+      expect(callOrder).toEqual(['heads', 'render', 'postRenderHeads'])
     })
   })
 


### PR DESCRIPTION
`React.renderToString` must be called before head hooks so that any styles/css for CSS-in-JS frameworks can be correctly generated and then injected into the `head`. This currently will only apply for synchronous rendering as handling streams with CSS-in-JS is a bit more [involved](https://medium.com/styled-components/v3-1-0-such-perf-wow-many-streams-c45c434dbd03#:~:text=Streaming%20server%2Dside%20rendering%20was,handle%20back%2Dpressure%20more%20easily.)