### PR TITLE
Fixed issue with trailing slashes breaking Router

### DIFF
--- a/packages/fastify-renderer/src/client/react/matcher.ts
+++ b/packages/fastify-renderer/src/client/react/matcher.ts
@@ -9,7 +9,7 @@ import { MatcherFn } from 'wouter'
  */
 const convertPathToRegexp = (path: string) => {
   const keys: Key[] = []
-  const regexp = pathToRegexp(path, keys, { strict: true })
+  const regexp = pathToRegexp(path, keys)
   return { keys, regexp }
 }
 


### PR DESCRIPTION
Ran into an issue where trailing slashes would break `wouter`'s routes for us, I think unless other people require the flexibility of having strict routes we can disable it by default.